### PR TITLE
Add categorizations to the default InformationType entry

### DIFF
--- a/src/trestle_gsa/core/system_characteristics.py
+++ b/src/trestle_gsa/core/system_characteristics.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from trestle.oscal.ssp import AuthorizationBoundary as AuthorizationBoundaryBase
 from trestle.oscal.ssp import DataFlow as DataFlowBase
@@ -7,7 +7,7 @@ from trestle.oscal.ssp import Impact as ImpactBase
 from trestle.oscal.ssp import InformationType as InformationTypeBase
 from trestle.oscal.ssp import SystemCharacteristics as SystemCharacteristicsBase
 from trestle.oscal.ssp import SystemInformation as SystemInformationBase
-from trestle.oscal.ssp import Selected, SecurityImpactLevel
+from trestle.oscal.ssp import Selected, SecurityImpactLevel, Categorization
 from trestle.oscal.common import ResponsibleParty, Property, Link
 
 from pydantic.v1 import Field, validator
@@ -44,6 +44,8 @@ class InformationType(InformationTypeBase):
     confidentiality_impact: Impact
     integrity_impact: Impact
     availability_impact: Impact
+    categorizations: Optional[List[Categorization]] = Field(
+        [Categorization(system="http://doi.org/10.6028/NIST.SP.800-60v2r1", information_type_ids=["REPLACE_ME"])])
 
 
 class SystemInformation(SystemInformationBase):


### PR DESCRIPTION
No change in the validity rules, but add the optional `categorizations` field to the defaults output to guide people to entering the acutal 800-60 ids in the correct place.

## Follow ups after merge:
- [x] update docker-trestle requirements.txt with the new sha.